### PR TITLE
Update proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,24 @@ dependencies {
 -keepattributes *Annotation*
 ```
 
+Do not obfuscate oaid classes:
+
+```java
+-keep class XI.CA.XI.**{*;}
+-keep class XI.K0.XI.**{*;}
+-keep class XI.XI.K0.**{*;}
+-keep class XI.xo.XI.XI.**{*;}
+-keep class com.asus.msa.SupplementaryDID.**{*;}
+-keep class com.asus.msa.sdid.**{*;}
+-keep class com.bun.lib.**{*;}
+-keep class com.bun.miitmdid.**{*;}
+-keep class com.huawei.hms.ads.identifier.**{*;}
+-keep class com.samsung.android.deviceidservice.**{*;}
+-keep class com.zui.opendeviceidlibrary.**{*;}
+-keep class org.json.**{*;}
+-keep public class com.netease.nis.sdkwrapper.Utils {public <methods>;}
+```
+
 If you are using Huawei libraries, you can to use these setttings:
 
 ```java


### PR DESCRIPTION
I've implemented tenjin sdk, it worked well on debug builds, but not on release builds.
Then I found the error logs:
![image](https://user-images.githubusercontent.com/13329148/148066007-6636aac6-42fd-42a2-bf8f-8b7506598633.png)

Dug into the code:
![image](https://user-images.githubusercontent.com/13329148/148066287-6f4b6c02-3a0d-4716-a9b2-c4a6c0b1456c.png)

Some classes from oaid sdk are optimized and removed, so the initiation process as code above will never succeed. 

The result I got was that the http connection response code of tenjin event was always 202. I cannot guarantee the obfuscation rules are the key points, but they actually solved my problems.

Here is a related issue: https://github.com/adtalos/flutter_msa_sdk/issues/9

- [ ] Reviewed by assignee
- [ ] Branch removed
